### PR TITLE
Multiplex GET request.

### DIFF
--- a/python/functions/main.py
+++ b/python/functions/main.py
@@ -114,3 +114,27 @@ def GET_run(request):
     run_id = args['run_id']
 
     return {"blockfaces": run_get(run_id)}
+
+def GET(request):
+    """
+    This function is the user-facing part of the function. It passes its input to the correct GET
+    method. Requests are multiplexed behind this method to reduce cold start time.
+    """
+    args = request.args
+    if 'request_type' not in args:
+        raise ValueError("This request is missing the required 'request_type' URL parameter.")
+    
+    t = args['request_type']
+    if t == 'run':
+        return GET_run(request)
+    elif t == 'sector':
+        return GET_sector(request)
+    elif t == 'coord':
+        return GET_coord(request)
+    elif t == 'radial':
+        return GET_radial(request)
+    else:
+        raise ValueError(
+            f"Received request with invalid 'request_type' value {t!r}. 'request_type' must be "
+            f"one of 'run', 'sector', 'coord', or 'radial'."
+        )

--- a/python/functions/tests/tests.py
+++ b/python/functions/tests/tests.py
@@ -112,7 +112,7 @@ class Test_GET_radial(unittest.TestCase):
     @insert_grid
     def testGetZero(self):
         response = requests.get(
-            f"{F_URL}?x=0&y=0&distance=0&include_na=False&offset=0"
+            f"{F_URL}?request_type=radial&x=0&y=0&distance=0&include_na=False&offset=0"
         )
         response.raise_for_status()
         assert response.json() is not None
@@ -125,7 +125,7 @@ class Test_GET_radial(unittest.TestCase):
         write_pickups(pickups)
 
         response = requests.get(
-            f"{F_URL}?x=0&y=0&distance=1&include_na=False&offset=0"
+            f"{F_URL}?request_type=radial&x=0&y=0&distance=1&include_na=False&offset=0"
         )
         response.raise_for_status()
         result = response.json()
@@ -143,7 +143,7 @@ class Test_GET_radial(unittest.TestCase):
         write_pickups(pickups)
 
         response = requests.get(
-            f"{F_URL}?x=0&y=0&distance=1&include_na=False&offset=0"
+            f"{F_URL}?request_type=radial&x=0&y=0&distance=1&include_na=False&offset=0"
         )
         response.raise_for_status()
         result = response.json()
@@ -167,7 +167,7 @@ class Test_GET_sector(unittest.TestCase):
         write_pickups(pickups)
 
         response = requests.get(
-            f"{F_URL}?sector_name=Polygon%20Land&include_na=False&offset=0"
+            f"{F_URL}?request_type=sector&sector_name=Polygon%20Land&include_na=False&offset=0"
         )
         response.raise_for_status()
         result = response.json()
@@ -187,7 +187,7 @@ class Test_GET_coord(unittest.TestCase):
         pickups = valid_pickups_from_geoms([Point(0.1, 0), Point(0.9, 0)], curb='left')
         write_pickups(pickups)
 
-        response = requests.get(f"{F_URL}?x=0&y=0&include_na=False&offset=0")
+        response = requests.get(f"{F_URL}?request_type=coord&x=0&y=0&include_na=False&offset=0")
         response.raise_for_status()
         result = response.json()
 
@@ -204,7 +204,7 @@ class Test_GET_run(unittest.TestCase):
         )
         write_pickups(pickups)
 
-        response = requests.get(f"{F_URL}?run_id=foo")
+        response = requests.get(f"{F_URL}?request_type=run&run_id=foo")
         response.raise_for_status()
         result = response.json()
 

--- a/scripts/deploy_private_api.sh
+++ b/scripts/deploy_private_api.sh
@@ -51,7 +51,7 @@ fi
 
 # Finally we are ready to deploy our functions.
 echo "Deploying cloud functions...⚙️"
-for FNAME in POST_pickups GET_radial GET_sector GET_coord GET_run
+for FNAME in POST_pickups GET
 do
     gcloud functions deploy $FNAME \
         --ingress-settings=internal-only \


### PR DESCRIPTION
Use a single GET endpoint instead of multiple ones. This should reduce propensity for cold starts.