### PR TITLE
Implement private API authentication

### DIFF
--- a/python/functions/requirements.txt
+++ b/python/functions/requirements.txt
@@ -4,3 +4,5 @@ psycopg2
 geoalchemy2
 scipy
 click
+flask
+firebase-admin

--- a/python/functions/tests/tests.py
+++ b/python/functions/tests/tests.py
@@ -51,12 +51,10 @@ if "WEB_API_KEY" not in os.environ:
         "https://console.firebase.google.com/project/_/settings/general."
         "To learn more about GCP API keys refer to: "
         "https://cloud.google.com/docs/authentication/api-keys?visit_id=637331240698538048-645747484&rd=1"
+        "Unfortunately this cannot be set for you automatically, as GCP API Keys have no public "
+        "programmtic key API. See further: https://stackoverflow.com/q/61623786/1993206."
     )
 
-# with open(os.environ["GOOGLE_APPLICATION_CREDENTIALS"], "r") as f:
-#     cfg = json.load(f)
-# DATABASE_URL = cfg["project_id"]
-# PRIVATE_KEY = cfg["private_key"]
 WEB_API_KEY = os.environ["WEB_API_KEY"]
 
 app = firebase_admin.initialize_app()

--- a/python/rubbish_geo_admin/setup.py
+++ b/python/rubbish_geo_admin/setup.py
@@ -8,7 +8,9 @@ setup(
         'sqlalchemy', 'psycopg2', 'geoalchemy2', 'click', 'osmnx', 'geopandas>=0.8.0', 'geopy',
         'rich', 'scipy'
     ],
-    extras_require={'develop': ['alembic', 'pylint', 'pytest', 'functions-framework']},
+    extras_require={'develop': [
+        'alembic', 'pylint', 'pytest', 'functions-framework', 'firebase-admin'
+    ]},
     entry_points='''
         [console_scripts]
         rubbish-admin=rubbish_geo_admin.cli:cli

--- a/scripts/reset_local_postgis_db.sh
+++ b/scripts/reset_local_postgis_db.sh
@@ -21,8 +21,4 @@ docker run -d \
 pushd ../python/migrations && \
     docker exec -it rubbish-db-container alembic -c test_alembic.ini upgrade head && \
     popd
-./wait_for_postgres.sh
-pushd ../python/migrations && \
-    docker exec -it rubbish-db-container alembic -c test_alembic.ini upgrade head && \
-    popd
 echo "PostGIS ready!"

--- a/scripts/run_local_integration_tests.sh
+++ b/scripts/run_local_integration_tests.sh
@@ -29,6 +29,7 @@ echo "Sleeping for five seconds to give the emulators time to start up..."
 sleep 5
 
 echo "Running private API integration test..."
+export GOOGLE_APPLICATION_CREDENTIALS=$RUBBISH_BASE_DIR/js/serviceAccountKey.json
 PRIVATE_API_EMULATOR_HOST="http://localhost:8081" \
     pytest $RUBBISH_BASE_DIR/python/functions/tests/tests.py -k POST_pickups
 


### PR DESCRIPTION
Looking at the risk of cold starts, and seeing that there was not much "special sauce" that being in the firestore functions gave us, I went ahead and implemented authentication into the Python-based private API.