### PR TITLE
Update get-db to list all connection strings

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -30,6 +30,7 @@ To test that this installed successfully, try running `rubbish-admin --help`&mda
 Before you can run the tests for the first time, you will first need to build the database Docker image:
 
 ```bash
+# PWD=rubbish-geo
 $ docker build --file Dockerfile.database --tag rubbish-db .
 ```
 
@@ -38,6 +39,8 @@ After this you can run the Python unit tests via:
 ```bash
 $ /scripts/run_local_unit_tests.sh
 ```
+
+This script will launch (or restart) the database container the container automatically, so no `docker run` is necessary.
 
 ## migrations
 

--- a/python/rubbish_geo_admin/rubbish_geo_admin/cli.py
+++ b/python/rubbish_geo_admin/rubbish_geo_admin/cli.py
@@ -9,7 +9,7 @@ import subprocess
 from rubbish_geo_common.db_ops import set_db as _set_db, reset_db as _reset_db, get_db as _get_db
 from .ops import (
     update_zone as _update_zone, insert_sector as _insert_sector, delete_sector as _delete_sector,
-    show_sectors as _show_sectors, show_zones as _show_zones
+    show_sectors as _show_sectors, show_zones as _show_zones, show_dbs
 )
 
 @click.group()
@@ -30,14 +30,17 @@ def connect(profile):
     psql = sp.stdout.decode("utf-8").rstrip()
     os.execl(psql, psql, connstr)
 
-@click.command(name="get-db", short_help="Prints the DB connection string.")
-@click.option("-p", "--profile", help="Optional profile. If not set uses default profile.")
+@click.command(name="get-db", short_help="Prints the DB connection strings.")
+@click.option("-p", "--profile", help="Optional profile. If set, prints just that string.")
 def get_db(profile):
-    connstr = _get_db(profile=profile)
-    if connstr:
-        print(connstr)
+    if profile is None:
+        show_dbs()
     else:
-        print("Connection string not set.")
+        connstr = _get_db(profile=profile)
+        if connstr:
+            print(connstr)
+        else:
+            print("Connection string not set.")
 
 @click.command(name="set-db", short_help="Set the DB connection string.")
 @click.argument("dbstr")

--- a/python/rubbish_geo_common/rubbish_geo_common/db_ops.py
+++ b/python/rubbish_geo_common/rubbish_geo_common/db_ops.py
@@ -33,6 +33,14 @@ def set_db(dbstr, profile=None):
     with open(cfg_fp, "w") as f:
         cfg.write(f)
 
+def get_db_cfg():
+    cfg_fp = APPDIR / "config"
+    if not cfg_fp.exists():
+        return None
+    cfg = configparser.ConfigParser()
+    cfg.read(cfg_fp)
+    return cfg
+
 def get_db(profile=None):
     """
     Gets the current database. Returns None if unset.
@@ -43,11 +51,7 @@ def get_db(profile=None):
     if profile is None:
         profile = 'default'
 
-    cfg_fp = APPDIR / "config"
-    if not cfg_fp.exists():
-        return None
-    cfg = configparser.ConfigParser()
-    cfg.read(cfg_fp)
+    cfg = get_db_cfg()
     return cfg[profile]['connstr']
 
 def db_sessionmaker(profile=None):
@@ -91,4 +95,4 @@ def reset_db(profile=None):
     finally:
         session.close()
 
-__all__ = ['set_db', 'get_db', 'db_sessionmaker', 'reset_db']
+__all__ = ['set_db', 'get_db_cfg', 'get_db', 'db_sessionmaker', 'reset_db']


### PR DESCRIPTION
Otherwise it's really hard to tell which database connection strings you have already defined.

Also fixes a bug in the centerline counting logic in `show_zones`.