### PR TITLE
Correct database connection behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ default.profraw
 fixtures/
 notebooks/
 *.ipynb
+cloud_sql_proxy

--- a/python/functions/requirements.txt
+++ b/python/functions/requirements.txt
@@ -6,3 +6,4 @@ scipy
 click
 flask
 firebase-admin
+pg8000  # See GH#64

--- a/python/functions/tests/tests.py
+++ b/python/functions/tests/tests.py
@@ -37,7 +37,7 @@ import firebase_admin.auth
 # lookup the id token.
 #
 # Note that this user will show up in Firebase's authentication console as a new user (with user 
-# UID 'polkstreet'): https://console.firebase.google.com/project/PROJECT/authentication/users.
+# UID 'polkstreet'): https://console.firebase.google.com/project/_/authentication/users.
 if "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
     raise ValueError(
         "The 'GOOGLE_APPLICATION_CREDENTIALS' environment variable must be set and must point "
@@ -52,7 +52,6 @@ if "WEB_API_KEY" not in os.environ:
         "To learn more about GCP API keys refer to: "
         "https://cloud.google.com/docs/authentication/api-keys?visit_id=637331240698538048-645747484&rd=1."
     )
-
 WEB_API_KEY = os.environ["WEB_API_KEY"]
 
 app = firebase_admin.initialize_app()

--- a/python/functions/tests/tests.py
+++ b/python/functions/tests/tests.py
@@ -50,9 +50,7 @@ if "WEB_API_KEY" not in os.environ:
         "This value may be read from the settings page for your project: "
         "https://console.firebase.google.com/project/_/settings/general."
         "To learn more about GCP API keys refer to: "
-        "https://cloud.google.com/docs/authentication/api-keys?visit_id=637331240698538048-645747484&rd=1"
-        "Unfortunately this cannot be set for you automatically, as GCP API Keys have no public "
-        "programmtic key API. See further: https://stackoverflow.com/q/61623786/1993206."
+        "https://cloud.google.com/docs/authentication/api-keys?visit_id=637331240698538048-645747484&rd=1."
     )
 
 WEB_API_KEY = os.environ["WEB_API_KEY"]

--- a/scripts/deploy_postgis_db.sh
+++ b/scripts/deploy_postgis_db.sh
@@ -34,7 +34,8 @@ else
         --region="us-west1"
     gcloud sql users set-password postgres --instance=$INSTANCE_NAME \
         --password=$RUBBISH_GEO_POSTGRES_USER_PASSWORD
-    # NOTE(aleksey): instance names are reserved for a while even after deletion, thus the $RANDOM.
+    # NOTE(aleksey): instance names are reserved for a while even after deletion, thus the $RANDOM
+    # to avoid collisions.
     INSTANCE_NAME="rubbish-geo-postgis-db-$RANDOM"
 fi
 
@@ -72,6 +73,8 @@ pushd $TMPDIR && alembic -c migrations/remote_alembic.ini upgrade head && popd
 echo "Adding this database to your local database profiles...✏️"
 rubbish-admin set-db --profile $RUBBISH_GEO_ENV $RW_RUBBISH_DB_CONNSTR
 
-echo "Done! You can now connect to this database by running: "
+echo "Done! If this database is local you can now connect to it by running: "
 echo "\$ rubbish-admin connect --profile $RUBBISH_GEO_ENV"
 echo "To connect directly, use the following database connection string: $RW_RUBBISH_DB_CONNSTR."
+echo "If this database is on GCP you will need to deploy the GCP SQL Proxy first. See futher: "
+echo "https://cloud.google.com/sql/docs/postgres/sql-proxy"

--- a/scripts/run_dev_integration_tests.sh
+++ b/scripts/run_dev_integration_tests.sh
@@ -2,11 +2,43 @@
 # Runs the integration tests in dev.
 set -e
 
-# Set this to the PostGIS database URI. This value will be read by rubbish.common.db_ops.get_db
-# at function runtime.
-# if [[ -z "$RUBBISH_POSTGIS_CONNSTR" ]]; then
-#     echo "RUBBISH_POSTGIS_CONNSTR environment variable not set, exiting." && exit 1
-# fi
+# Set this to the read_write user password.
+if [[ -z "$RUBBISH_GEO_READ_WRITE_USER_PASSWORD" ]]; then
+    echo "RUBBISH_GEO_READ_WRITE_USER_PASSWORD environment variable not set, exiting." && exit 1
+fi
+# The connection name will be a string in the format "PROJECT:REGION:INSTANCE". It is available
+# on the "Overview" page in the Cloud SQL web console.
+if [[ -z "$RUBBISH_POSTGIS_CONNECTION_NAME" ]]; then
+    echo "RUBBISH_POSTGIS_CONNECTION_NAME environment variable not set, exiting." && exit 1
+fi
+
+# Stand up the Cloud SQL Proxy.
+echo "Starting cloud sql proxy..."
+# Use port 5433 to avoid collisions with any local Postgres instance (which default to 5432)
+PORT_IN_USE=$(nc -z 127.0.0.1 5433 && echo "IN USE" || echo "FREE")
+if [[ "$PORT_IN_USE" == "IN USE" ]]; then
+    echo "Could not start script: port 5433 unavailable."
+    exit 1
+fi
+pushd ../ 1>&0 && RUBBISH_BASE_DIR=$(echo $PWD) && popd 1>&0
+ls $RUBBISH_BASE_DIR | grep cloud_sql_proxy && CLOUD_SQL_PROXY_INSTALLED=0 || \
+    CLOUD_SQL_PROXY_INSTALLED=1
+if [[ CLOUD_SQL_PROXY_INSTALLED -eq 1 ]]; then
+    echo "Downloading cloud sql proxy..."
+    # NOTE: this URL assumes you are on a macOS machine, for a Linux link refer to
+    # https://cloud.google.com/sql/docs/postgres/quickstart-proxy-test
+    curl -o $RUBBISH_BASE_DIR/cloud_sql_proxy \
+        https://dl.google.com/cloudsql/cloud_sql_proxy.darwin.amd64
+    chmod +x $RUBBISH_BASE_DIR/cloud_sql_proxy
+fi
+$RUBBISH_BASE_DIR/cloud_sql_proxy -instances=$RUBBISH_POSTGIS_CONNECTION_NAME=tcp:5433 &
+RUBBISH_POSTGIS_CONNSTR=postgresql://read_write:$RUBBISH_GEO_READ_WRITE_USER_PASSWORD@localhost:5433/rubbish
+
+# Set this to the Firebase project's web API key:
+# https://console.firebase.google.com/project/_/settings/general.
+if [[ -z "$WEB_API_KEY" ]]; then
+    echo "WEB_API_KEY environment variable not set, exiting." && exit 1
+fi
 
 echo "Setting environment variables..."
 pushd ../ 1>&0 && RUBBISH_BASE_DIR=$(echo $PWD) && popd 1>&0
@@ -14,15 +46,16 @@ export GOOGLE_APPLICATION_CREDENTIALS=$RUBBISH_BASE_DIR/js/serviceAccountKey.jso
 export RUBBISH_GEO_ENV=dev
 GCP_PROJECT=$(gcloud config get-value project)
 REGION=us-central1  # currently a hardcoded value
-POST_PICKUPS_URL=https://$REGION-$GCP_PROJECT.cloudfunctions.net/POST_pickups
+# POST_PICKUPS_URL=https://$REGION-$GCP_PROJECT.cloudfunctions.net/POST_pickups
 GET_URL=https://$REGION-$GCP_PROJECT.cloudfunctions.net/GET
-
-echo $GET_URL
 
 echo "Running private API integration tests..."
 # NOTE(aleksey): POST_pickups only allows internal traffic, so we can't test it directly like
 # we can with GET.
 # PRIVATE_API_HOST=$POST_PICKUPS_URL \
 #     pytest $RUBBISH_BASE_DIR/python/functions/tests/tests.py -k POST_pickups
-PRIVATE_API_HOST=$GET_URL \
+PRIVATE_API_HOST=$GET_URL RUBBISH_POSTGIS_CONNSTR=$RUBBISH_POSTGIS_CONNSTR \
     pytest $RUBBISH_BASE_DIR/python/functions/tests/tests.py -k GET
+
+echo "Shutting down cloud sql proxy..."
+kill -s SIGSTOP %1

--- a/scripts/run_dev_integration_tests.sh
+++ b/scripts/run_dev_integration_tests.sh
@@ -4,9 +4,9 @@ set -e
 
 # Set this to the PostGIS database URI. This value will be read by rubbish.common.db_ops.get_db
 # at function runtime.
-if [[ -z "$RUBBISH_POSTGIS_CONNSTR" ]]; then
-    echo "RUBBISH_POSTGIS_CONNSTR environment variable not set, exiting." && exit 1
-fi
+# if [[ -z "$RUBBISH_POSTGIS_CONNSTR" ]]; then
+#     echo "RUBBISH_POSTGIS_CONNSTR environment variable not set, exiting." && exit 1
+# fi
 
 echo "Setting environment variables..."
 pushd ../ 1>&0 && RUBBISH_BASE_DIR=$(echo $PWD) && popd 1>&0
@@ -16,6 +16,8 @@ GCP_PROJECT=$(gcloud config get-value project)
 REGION=us-central1  # currently a hardcoded value
 POST_PICKUPS_URL=https://$REGION-$GCP_PROJECT.cloudfunctions.net/POST_pickups
 GET_URL=https://$REGION-$GCP_PROJECT.cloudfunctions.net/GET
+
+echo $GET_URL
 
 echo "Running private API integration tests..."
 # NOTE(aleksey): POST_pickups only allows internal traffic, so we can't test it directly like

--- a/scripts/run_local_integration_tests.sh
+++ b/scripts/run_local_integration_tests.sh
@@ -2,6 +2,13 @@
 # Runs the integration tests locally.
 set -e
 
+# The 'WEB_API_KEY' environment variable must be set to the project's web API key.
+# This value may be read from the settings page for the project:
+# https://console.firebase.google.com/project/_/settings/general.
+if [[ -z "$WEB_API_KEY" ]]; then
+    echo "WEB_API_KEY environment variable not set, exiting." && exit 1
+fi
+
 # Check ports.
 for PORT in 5001 8080 8081
 do


### PR DESCRIPTION
Cloud Functions do not allow direct access to Cloud SQL even though they're in the same VPC :(. The only documented code path for accessing Cloud SQL from inside of a Cloud Function is one that uses UNIX sockets.

pg8000 is a pure-Python Postgres DB connector implementation. We're using it here instead of the more typical psycops2 because psycops2 doesn't support GCP's (mandatory) UNIX socket connection code path.