### PR TITLE
Enable user SQL access to GCP databases

### DIFF
--- a/python/rubbish_geo_admin/rubbish_geo_admin/ops.py
+++ b/python/rubbish_geo_admin/rubbish_geo_admin/ops.py
@@ -117,6 +117,44 @@ def _poly_wkb_to_bounds_str(wkb):
     bounds = str(tuple(f'{v:.4f}' for v in bounds)).replace("'", "")
     return bounds
 
+def run_cloud_sql_proxy(force_download=False):
+    """
+    Internal method. Does the song and dance Google requires to shell psql through to a DB.
+    """
+    print("GOT TO METHOD")
+    import pathlib
+    import click
+    import subprocess
+    import socket
+    import stat
+    import requests
+    import shutil
+
+    APPDIR = pathlib.Path(click.get_app_dir("rubbish", force_posix=True))
+    outpath = APPDIR / "cloud_sql_proxy"
+    if not outpath.exists() or force_download:
+        # this is the macOS path, so this method only currently works on macOS
+        dl_url = "https://dl.google.com/cloudsql/cloud_sql_proxy.darwin.amd64"
+        proxy_bytes = requests.get(dl_url)
+        proxy_bytes.raw.decode_content = True
+        with open(outpath, "wb") as f:
+            f.write(proxy_bytes.content)
+
+        try:
+            os.chmod(outpath, stat.S_IEXEC)
+        except OSError:
+            raise OSError(
+                "Could not mark the cloud_sql_proxy script as executable. You may have to do "
+                "this yourself: run 'chmod +x ~/.rubbish/cloud_sql_proxy' in the terminal."
+            )
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        port_occupied = s.connect_ex(('localhost', 5432)) == 0
+    if port_occupied:
+        raise OSError("Port 5432 already in use. You will have to free the port first.")
+
+    subprocess.Popen(f"{outpath.as_posix()}")
+
 def update_zone(osmnx_name, name, centerlines=None, profile=None):
     """
     Updates a zone, plopping the new centerlines into the database.
@@ -203,7 +241,8 @@ def update_zone(osmnx_name, name, centerlines=None, profile=None):
     bbox = f'SRID=4326;{str(poly)}'
     zone.bounding_box = bbox
 
-    conn = sa.create_engine(get_db())
+    connstr, _ = get_db()
+    conn = sa.create_engine(connstr)
 
     # Cap the previous centerline generations (see previous comment).
     previously_current_centerlines = (session
@@ -271,17 +310,19 @@ def show_zones(profile=None):
         console.print(table)
 
 def show_dbs():
-    """Pretty-prints a list of database connection strings."""
+    """Pretty-prints database connection information."""
     cfg = get_db_cfg()
     console = Console()
     table = Table(show_header=True, header_style="bold magenta")
     table.add_column("Profile", justify="left")
-    table.add_column("Value", justify="left")
+    table.add_column("Connection String", justify="left")
+    table.add_column("Type", justify="left")
     for profile in cfg:
         if profile == 'DEFAULT':
             continue
         value = cfg[profile]['connstr']
-        table.add_row(profile, value)
+        conntype = cfg[profile]['type']
+        table.add_row(profile, value, conntype)
     console.print(table)
 
 def _validate_sector_geom(filepath):
@@ -360,4 +401,7 @@ def show_sectors(profile=None):
         table.add_row(str(sector.id), sector.name, bounds)
     console.print(table)
 
-__all__ = ['update_zone', 'show_zones', 'insert_sector', 'delete_sector', 'show_sectors']
+__all__ = [
+    'update_zone', 'show_zones', 'insert_sector', 'delete_sector', 'show_sectors',
+    'run_cloud_sql_proxy'
+]

--- a/python/rubbish_geo_common/rubbish_geo_common/db_ops.py
+++ b/python/rubbish_geo_common/rubbish_geo_common/db_ops.py
@@ -15,12 +15,23 @@ from rubbish_geo_common.orm import (
 
 APPDIR = pathlib.Path(click.get_app_dir("rubbish", force_posix=True))
 
-def set_db(dbstr, conntype, profile=None):
+def set_db(dbstr, conntype, conname=None, profile=None):
     """
-    Sets the target database connection string (writing the input value to disk).
+    Sets the target database connection settings (writing the input value to disk).
     """
+    if conntype not in ["local", "gcp"]:
+        raise ValueError("conntype must be set to one of [local, gcp].")
     if profile is None:
         profile = 'default'
+    if conname is None:
+        if conntype == 'gcp':
+            raise ValueError(
+                "Databases of the 'gcp' type must specify a connection name, as this value "
+                "is required by the GCP cloud_sql_proxy. For more information refer to "
+                "https://cloud.google.com/sql/docs/postgres/sql-proxy."
+            )
+        else:
+            conntype = 'unset'
 
     if not APPDIR.exists():
         os.makedirs(APPDIR)
@@ -29,7 +40,7 @@ def set_db(dbstr, conntype, profile=None):
     cfg = configparser.ConfigParser()
     if cfg_fp.exists():
         cfg.read(cfg_fp)
-    cfg[profile] = {'connstr': dbstr, 'type': conntype}
+    cfg[profile] = {'connstr': dbstr, 'type': conntype, 'conname': conname}
     with open(cfg_fp, "w") as f:
         cfg.write(f)
 
@@ -43,7 +54,9 @@ def get_db_cfg():
 
 def get_db(profile=None):
     """
-    Gets the database connection string and type.
+    Gets the database connection string (what gets passed to psql or sqlalchemy at runtime), type
+    (local or gcp), and connection name (used by the cloud_sql_proxy and required for local
+    connections to GCP databases.
     """
     if 'RUBBISH_POSTGIS_CONNSTR' in os.environ:
         return os.environ['RUBBISH_POSTGIS_CONNSTR']
@@ -52,7 +65,7 @@ def get_db(profile=None):
         profile = 'default'
 
     cfg = get_db_cfg()
-    return cfg[profile]['connstr'], cfg[profile]['type']
+    return cfg[profile]['connstr'], cfg[profile]['type'], cfg[profile]['conname']
 
 def db_sessionmaker(profile=None):
     """
@@ -61,7 +74,7 @@ def db_sessionmaker(profile=None):
     if profile is None:
         profile = 'default'
     
-    connstr, _ = get_db(profile=profile)
+    connstr, _, _ = get_db(profile=profile)
     if connstr == None:
         raise ValueError("connection string not set, run set_db first")
     engine = sa.create_engine(connstr)

--- a/python/rubbish_geo_common/rubbish_geo_common/db_ops.py
+++ b/python/rubbish_geo_common/rubbish_geo_common/db_ops.py
@@ -15,7 +15,7 @@ from rubbish_geo_common.orm import (
 
 APPDIR = pathlib.Path(click.get_app_dir("rubbish", force_posix=True))
 
-def set_db(dbstr, profile=None):
+def set_db(dbstr, conntype, profile=None):
     """
     Sets the target database connection string (writing the input value to disk).
     """
@@ -29,7 +29,7 @@ def set_db(dbstr, profile=None):
     cfg = configparser.ConfigParser()
     if cfg_fp.exists():
         cfg.read(cfg_fp)
-    cfg[profile] = {'connstr': dbstr}
+    cfg[profile] = {'connstr': dbstr, 'type': conntype}
     with open(cfg_fp, "w") as f:
         cfg.write(f)
 
@@ -43,7 +43,7 @@ def get_db_cfg():
 
 def get_db(profile=None):
     """
-    Gets the current database. Returns None if unset.
+    Gets the database connection string and type.
     """
     if 'RUBBISH_POSTGIS_CONNSTR' in os.environ:
         return os.environ['RUBBISH_POSTGIS_CONNSTR']
@@ -52,7 +52,7 @@ def get_db(profile=None):
         profile = 'default'
 
     cfg = get_db_cfg()
-    return cfg[profile]['connstr']
+    return cfg[profile]['connstr'], cfg[profile]['type']
 
 def db_sessionmaker(profile=None):
     """
@@ -61,7 +61,7 @@ def db_sessionmaker(profile=None):
     if profile is None:
         profile = 'default'
     
-    connstr = get_db(profile=profile)
+    connstr, _ = get_db(profile=profile)
     if connstr == None:
         raise ValueError("connection string not set, run set_db first")
     engine = sa.create_engine(connstr)

--- a/python/rubbish_geo_common/rubbish_geo_common/test_utils.py
+++ b/python/rubbish_geo_common/rubbish_geo_common/test_utils.py
@@ -13,7 +13,7 @@ from rubbish_geo_common.consts import RUBBISH_TYPES
 
 def get_db(profile=None):
     if 'RUBBISH_GEO_ENV' not in os.environ or os.environ['RUBBISH_GEO_ENV'] == 'local':
-        return f"postgresql://rubbish-test-user:polkstreet@localhost:5432/rubbish", "local"
+        return f"postgresql://rubbish-test-user:polkstreet@localhost:5432/rubbish", "local", "unset"
     elif os.environ['RUBBISH_GEO_ENV'] == 'dev':
         if 'RUBBISH_POSTGIS_CONNSTR' not in os.environ:
             raise ValueError(
@@ -21,7 +21,7 @@ def get_db(profile=None):
                 f"{os.environ['RUBBISH_GEO_ENV']!r}, but the 'RUBBISH_POSTGIS_CONNSTR' value "
                 f"is unset. Set this value to the correct PostGIS instance connection string."
             )
-        return os.environ['RUBBISH_POSTGIS_CONNSTR'], "gcp"
+        return os.environ['RUBBISH_POSTGIS_CONNSTR'], "gcp", "unset"
     else:
         raise ValueError(
             f"'RUBBISH_GEO_ENV' must be set to one of 'local' or 'dev', but found value "

--- a/python/rubbish_geo_common/rubbish_geo_common/test_utils.py
+++ b/python/rubbish_geo_common/rubbish_geo_common/test_utils.py
@@ -13,7 +13,7 @@ from rubbish_geo_common.consts import RUBBISH_TYPES
 
 def get_db(profile=None):
     if 'RUBBISH_GEO_ENV' not in os.environ or os.environ['RUBBISH_GEO_ENV'] == 'local':
-        return f"postgresql://rubbish-test-user:polkstreet@localhost:5432/rubbish"
+        return f"postgresql://rubbish-test-user:polkstreet@localhost:5432/rubbish", "local"
     elif os.environ['RUBBISH_GEO_ENV'] == 'dev':
         if 'RUBBISH_POSTGIS_CONNSTR' not in os.environ:
             raise ValueError(
@@ -21,7 +21,7 @@ def get_db(profile=None):
                 f"{os.environ['RUBBISH_GEO_ENV']!r}, but the 'RUBBISH_POSTGIS_CONNSTR' value "
                 f"is unset. Set this value to the correct PostGIS instance connection string."
             )
-        return os.environ['RUBBISH_POSTGIS_CONNSTR']
+        return os.environ['RUBBISH_POSTGIS_CONNSTR'], "gcp"
     else:
         raise ValueError(
             f"'RUBBISH_GEO_ENV' must be set to one of 'local' or 'dev', but found value "

--- a/scripts/deploy_postgis_db.sh
+++ b/scripts/deploy_postgis_db.sh
@@ -70,8 +70,14 @@ cat $TMPDIR/migrations/alembic.ini | \
     $TMPDIR/migrations/remote_alembic.ini
 pushd $TMPDIR && alembic -c migrations/remote_alembic.ini upgrade head && popd
 
+# NOTE(aleksey): connecting to this instance requires cloud_sql_proxy.
 echo "Adding this database to your local database profiles...✏️"
-rubbish-admin set-db --profile $RUBBISH_GEO_ENV $RW_RUBBISH_DB_CONNSTR
+CONNAME=$(gcloud sql instances describe $INSTANCE_NAME --format=json | jq -r '.connectionName')
+rubbish-admin set-db \
+    postgresql://read_write:$RUBBISH_GEO_READ_WRITE_USER_PASSWORD@localhost:5432/rubbish \
+    gcp \
+    --conname $CONNAME \
+    --profile $RUBBISH_GEO_ENV
 
 echo "Done! If this database is local you can now connect to it by running: "
 echo "\$ rubbish-admin connect --profile $RUBBISH_GEO_ENV"


### PR DESCRIPTION
Adds a whole lot of information to the database config file. The need to run the `cloud_sql_proxy` process and clean it up manually after is hella awkward&mdash;thanks Google&mdash;but it'll do for now.