### PR TITLE
First stab at a load testing script

### DIFF
--- a/python/rubbish_geo_common/rubbish_geo_common/db_ops.py
+++ b/python/rubbish_geo_common/rubbish_geo_common/db_ops.py
@@ -59,7 +59,7 @@ def get_db(profile=None):
     connections to GCP databases.
     """
     if 'RUBBISH_POSTGIS_CONNSTR' in os.environ:
-        return os.environ['RUBBISH_POSTGIS_CONNSTR']
+        return os.environ['RUBBISH_POSTGIS_CONNSTR'], 'local', 'unset'
 
     if profile is None:
         profile = 'default'

--- a/scripts/load_test.py
+++ b/scripts/load_test.py
@@ -1,0 +1,69 @@
+from firebase_admin import firestore, initialize_app
+import os
+import pathlib
+
+from rubbish_geo_common.db_ops import reset_db
+from rubbish_geo_admin.ops import update_zone
+
+if __name__ == "__main__":
+    print("Initializing environment...")
+    if 'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ:
+        os.environ['GOOGLE_APPLICATION_CREDENTIALS'] =\
+            pathlib.Path('.').absolute().parent / 'js' / 'serviceAccountKey.json'
+    if 'RUBBISH_GEO_ENV' not in os.environ:
+        os.environ['RUBBISH_GEO_ENV'] = 'local'
+
+    # TODO: setting this environment variable points initialization at the local emulator instead
+    # of at the project-configured endpoint. But this is ugly. There must be a cleaner way...
+    try:
+        del os.environ['FIRESTORE_EMULATOR_HOST']
+    except KeyError:
+        pass
+    source_app = initialize_app(name='source')
+    source_db = firestore.client(app=source_app)
+    os.environ['FIRESTORE_EMULATOR_HOST'] = 'localhost:8080'
+    sink_app = initialize_app(name='sink', options={'databaseURL': 'localhost:8080'})
+    sink_db = firestore.client(app=sink_app)
+
+    source_stories = source_db.collection('RubbishRunStory').stream()
+    source_pickups = source_db.collection('Story')
+    sink_stories = sink_db.collection('RubbishRunStory')
+    sink_pickups = sink_db.collection('Story')
+
+    print("Resetting database...")
+    reset_db(profile='local')
+    print("Inserting San Francisco centerlines into database...")
+    update_zone('San Francisco, California', 'San Francisco, California', profile='local')
+    print("Done inserting San Francisco centerlines into database!")
+
+    def dictify(doc_ref):
+        return {**{field: doc_ref.get(field) for field in doc_ref._data}, 'id': doc_ref.id}
+
+    print("Writing runs to the user database...")
+    for idx, story in enumerate(source_stories):
+        story_to_write = dictify(story)
+        pickups_to_write = []
+
+        # this happens to be a signal that this is a test case, which doesn't follow
+        # the full schema, so we should skip it
+        if "-" in story.id:
+            continue
+        photoStoryIDs = story.get('photoStoryIDs')
+        story_id = story.id
+        for photoStoryID in photoStoryIDs:
+            pickup = source_pickups.document(photoStoryID)
+            pickup = pickup.get(
+                ['curb', 'lat', 'long', 'photoStoryID', 'rubbishType', 'userTimeStamp']
+            )
+            pickups_to_write.append({**dictify(pickup)})
+
+        for pickup_to_write in pickups_to_write:
+            pickup_id = pickup_to_write['id']
+            del pickup_to_write['id']
+            sink_pickups.document(pickup_id).set(pickup_to_write)
+
+        del story_to_write['id']
+        sink_stories.document(story_id).set(story_to_write)
+        break
+
+    print("Done writing runs to the user database!")

--- a/scripts/run_local_integration_tests.sh
+++ b/scripts/run_local_integration_tests.sh
@@ -22,9 +22,12 @@ done
 
 ./reset_local_postgis_db.sh
 
-echo "Starting functional API POST_pickups emulator..."
 pushd ../ 1>&0 && export RUBBISH_BASE_DIR=$(echo $PWD) && popd 1>&0
 export RUBBISH_POSTGIS_CONNSTR="postgresql://rubbish-test-user:polkstreet@localhost:5432/rubbish"
+export GOOGLE_APPLICATION_CREDENTIALS=$RUBBISH_BASE_DIR/js/serviceAccountKey.json
+export RUBBISH_GEO_ENV="local"
+
+echo "Starting functional API POST_pickups emulator..."
 functions-framework --source $RUBBISH_BASE_DIR/python/functions/main.py \
     --port 8081 --target POST_pickups --debug &
 
@@ -36,8 +39,6 @@ echo "Sleeping for five seconds to give the emulators time to start up..."
 sleep 5
 
 echo "Running functional API integration test..."
-export GOOGLE_APPLICATION_CREDENTIALS=$RUBBISH_BASE_DIR/js/serviceAccountKey.json
-export RUBBISH_GEO_ENV="local"
 FUNCTIONAL_API_HOST="http://localhost:8081" \
     pytest $RUBBISH_BASE_DIR/python/functions/tests/tests.py -k POST_pickups || true
 FUNCTIONAL_API_HOST="http://localhost:8082" \


### PR DESCRIPTION
This PR implements a load testing script. This script will be used to stream select runs from the prod user database to the local user database, thus triggering the local code path pushing those records through to the PostGIS database.

The intent of this script is twofold. One, it will be used to smoke test writing "real data" through the `rubbish-geo` stack (and reading it back out again). Two, it will be used to test the debug visualizations which are soon to be implemented in the `rubbish-admin` CLI.

The script currently targets `dev`, not `prod`. Next step will be to switch it to `prod` and see what happens.