### PR TITLE
Finish writing load testing script.

### DIFF
--- a/python/rubbish_geo_common/rubbish_geo_common/consts.py
+++ b/python/rubbish_geo_common/rubbish_geo_common/consts.py
@@ -1,7 +1,6 @@
 """
 Library constants.
 """
-# TODO: replace this map with the Firebase map.
 
 RUBBISH_TYPES = ['tobacco', 'paper', 'plastic', 'other', 'food', 'glass']
 RUBBISH_TYPE_MAP = {v: i for i, v in enumerate(RUBBISH_TYPES)}


### PR DESCRIPTION
After implementing this code, I was able to successfully insert a 420-ish pickup run into the database!

```bash
$ python dev_load_test.py rSha3Lu56sOeTwt1RCHh --reset-db
```

In the process I uncovered some pretty nastly incoherence in the `dev`/`prod` user database. As a result, I am now treating the database entries as schema-on-write, and liberally dropping pickups from the record which lack proper attribution (e.g. they have no `lat` or `long` set).

There's still a lot of fit-and-finish type tasks to do, but this is progress.