### PR TITLE
Make curbs an enum.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,12 @@ This script will launch (or restart) the database container the container automa
 
 ### migrations
 
-Database migrations using Alembic are located in the `migrations` subfolder. These are performed for you automatically when running tests.
+Database migrations using Alembic are located in the `migrations` subfolder. These are performed for you automatically when running tests. However, to test new/updated migrations or, you will need to rebuild the container first:
+
+```bash
+# PWD=rubbish-geo
+docker build . --file Dockerfile.database --tag rubbish-db:latest
+```
 
 ### ci
 

--- a/python/functions/main.py
+++ b/python/functions/main.py
@@ -84,7 +84,7 @@ def POST_pickups(request):
                 "firebase_id": <int>,
                 "type": <str; from {'tobacco', 'paper', 'plastic', 'other', 'food', 'glass'}>,
                 "timestamp": <int; UTC UNIX timestamp>,
-                "curb": <{'left', 'right', None}; user statement of side of the street>,
+                "curb": <{'left', 'right', 'center', None}; side of the street>,
                 "geometry": <str; POINT in WKT format>
             }
         ]

--- a/python/migrations/versions/a3fa9dac3f4e_initialize_db.py
+++ b/python/migrations/versions/a3fa9dac3f4e_initialize_db.py
@@ -9,6 +9,7 @@ Create Date: 2020-05-22 13:04:13.231880
 """
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM
 from geoalchemy2 import Geometry
 
 # revision identifiers, used by Alembic.
@@ -71,7 +72,7 @@ def upgrade():
         sa.Column("geometry", Geometry("POINT", srid=4326), nullable=False),
         sa.Column("snapped_geometry", Geometry("POINT", srid=4326), nullable=False),
         sa.Column("linear_reference", sa.Float(precision=3)),
-        sa.Column("curb", sa.Integer, nullable=False),  # side-of-street
+        sa.Column("curb", ENUM('left', 'right', 'center', name='curb'), nullable=False)
     )
     # Blockfaces are a psuedo-virtual table defined by the combination of {centerline,curb}.
     # A centerline will typically have two blockfaces: one for the left side of the street and
@@ -83,7 +84,7 @@ def upgrade():
         "blockface_statistics",
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column("centerline_id", sa.Integer, sa.ForeignKey("centerlines.id"), nullable=False),
-        sa.Column("curb", sa.Integer, nullable=False),
+        sa.Column("curb", ENUM('left', 'right', 'center', name='curb'), nullable=False),
         sa.Column("rubbish_per_meter", sa.Float, nullable=False, index=True),
         sa.Column("num_runs", sa.Integer, nullable=False)
     )

--- a/python/rubbish_geo_common/rubbish_geo_common/orm.py
+++ b/python/rubbish_geo_common/rubbish_geo_common/orm.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from geoalchemy2 import Geometry
@@ -76,7 +77,7 @@ class Pickup(Base):
     geometry = sa.Column("geometry", Geometry("POINT"), nullable=False)
     snapped_geometry = sa.Column("snapped_geometry", Geometry("POINT"), nullable=False)
     linear_reference = sa.Column("linear_reference", sa.Float(precision=3))
-    curb = sa.Column("curb", sa.Integer, nullable=False)
+    curb = sa.Column("curb", ENUM('left', 'right', 'center', name='curb'), nullable=False)
     centerline = relationship("Centerline", back_populates="pickups")
 
     def __repr__(self):
@@ -94,7 +95,7 @@ class BlockfaceStatistic(Base):
     id = sa.Column("id", sa.Integer, primary_key=True)
     centerline_id =\
         sa.Column("centerline_id", sa.Integer, sa.ForeignKey("centerlines.id"), nullable=False)
-    curb = sa.Column("curb", sa.Integer, nullable=False)
+    curb = sa.Column("curb", ENUM('left', 'right', 'center', name='curb'), nullable=False)
     rubbish_per_meter = sa.Column("rubbish_per_meter", sa.Float, nullable=False)
     num_runs = sa.Column("num_runs", sa.Integer, nullable=False)
     centerline = relationship("Centerline", back_populates="blockface_statistics")


### PR DESCRIPTION
This PR makes `curb` a [Postgres ENUM type](https://www.postgresql.org/docs/current/datatype-enum.html). Prior to this `curb` was an integer, which admittedly was never a good choice.

This PR also adds support for `center` curb values.