### PR TITLE
Improve cloud_sql_proxy handling

### DIFF
--- a/python/rubbish_geo_admin/rubbish_geo_admin/ops.py
+++ b/python/rubbish_geo_admin/rubbish_geo_admin/ops.py
@@ -16,7 +16,9 @@ from shapely.geometry import Polygon
 from rich.console import Console
 from rich.table import Table
 
-from rubbish_geo_common.db_ops import db_sessionmaker, get_db, get_db_cfg
+from rubbish_geo_common.db_ops import (
+    db_sessionmaker, get_db, get_db_cfg, OptionalCloudSQLProxyProcess
+)
 from rubbish_geo_common.orm import Zone, ZoneGeneration, Centerline, Sector
 
 def _get_name_for_centerline_edge(G, u, v):
@@ -117,51 +119,7 @@ def _poly_wkb_to_bounds_str(wkb):
     bounds = str(tuple(f'{v:.4f}' for v in bounds)).replace("'", "")
     return bounds
 
-def run_cloud_sql_proxy(profile, force_download=False):
-    """
-    Internal method. Does the song and dance Google requires to shell psql through to a DB.
-    """
-    print("GOT TO METHOD")
-    import pathlib
-    import click
-    import subprocess
-    import socket
-    import stat
-    import requests
-
-    if profile is None:
-        profile = 'default'
-
-    APPDIR = pathlib.Path(click.get_app_dir("rubbish", force_posix=True))
-    outpath = APPDIR / "cloud_sql_proxy"
-    if not outpath.exists() or force_download:
-        # this is the macOS path, so this method only currently works on macOS
-        dl_url = "https://dl.google.com/cloudsql/cloud_sql_proxy.darwin.amd64"
-        proxy_bytes = requests.get(dl_url)
-        proxy_bytes.raw.decode_content = True
-        with open(outpath, "wb") as f:
-            f.write(proxy_bytes.content)
-
-        try:
-            os.chmod(outpath, stat.S_IEXEC)
-        except OSError:
-            raise OSError(
-                "Could not mark the cloud_sql_proxy script as executable. You may have to do "
-                "this yourself: run 'chmod +x ~/.rubbish/cloud_sql_proxy' in the terminal."
-            )
-
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        port_occupied = s.connect_ex(('localhost', 5432)) == 0
-    if port_occupied:
-        raise OSError(
-            "This method needs to launch the cloud_sql_proxy daemon on port 5432, but port is "
-            "already in use. You will have to free the port first."
-        )
-
-    _, _, conname = get_db(profile)
-    return subprocess.Popen([f"{outpath.as_posix()}", f"-instances={conname}=tcp:5432"])
-
-def update_zone(osmnx_name, name, profile, centerlines=None):
+def update_zone(osmnx_name, name, profile, centerlines=None, wait=5, force_download=False):
     """
     Updates a zone, plopping the new centerlines into the database.
 
@@ -169,151 +127,155 @@ def update_zone(osmnx_name, name, profile, centerlines=None):
     
     The optional `centerlines` argument is used to avoid a network request in testing.
     """
-    session = db_sessionmaker(profile)()
+    with OptionalCloudSQLProxyProcess(profile, wait=wait, force_download=force_download):
+        session = db_sessionmaker(profile)()
 
-    # insert zone
-    # NOTE: flush writes DB ops to the database's transactional buffer without actually
-    # performing a commit (and closing the transaction). This is important because it 
-    # allows us to reserve a primary key ID from the corresponding auto-increment 
-    # sequence, which we need when we use it as a foreign key. See SO#620610.
-    if name is None:
-        name = osmnx_name
-    zone_query = (session
-        .query(Zone)
-        .filter(Zone.osmnx_name == osmnx_name)
-        .one_or_none()
-    )
-    zone_already_exists = zone_query is not None
-    if zone_already_exists:
-        zone = zone_query
-    else:
-        # We need to satisfy the non-null bounding box constraint to flush, but we don't have the
-        # centerlines yet so we can't calculate it yet. For now, just use temporary boundaries.
-        temp_bbox = f'SRID=4326;{str(Polygon([[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]))}'
-        zone = Zone(osmnx_name=osmnx_name, name=name, bounding_box=temp_bbox)
-        session.add(zone)
+        # insert zone
+        # NOTE: flush writes DB ops to the database's transactional buffer without actually
+        # performing a commit (and closing the transaction). This is important because it 
+        # allows us to reserve a primary key ID from the corresponding auto-increment 
+        # sequence, which we need when we use it as a foreign key. See SO#620610.
+        if name is None:
+            name = osmnx_name
+        zone_query = (session
+            .query(Zone)
+            .filter(Zone.osmnx_name == osmnx_name)
+            .one_or_none()
+        )
+        zone_already_exists = zone_query is not None
+        if zone_already_exists:
+            zone = zone_query
+        else:
+            # We need to satisfy the non-null bounding box constraint to flush, but we don't have
+            # the centerlines yet so we can't calculate it yet. For now, just use temp bounds.
+            temp_bbox = f'SRID=4326;{str(Polygon([[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]))}'
+            zone = Zone(osmnx_name=osmnx_name, name=name, bounding_box=temp_bbox)
+            session.add(zone)
+            session.flush()
+
+        # modify old and insert new zone generation
+        if zone_already_exists:
+            zone_generation_query = (session
+                .query(ZoneGeneration)
+                .filter(ZoneGeneration.zone_id == zone.id)
+                .order_by(ZoneGeneration.generation)
+                .all()
+            )
+            next_zone_generation = zone_generation_query[-1].generation + 1
+        else:
+            next_zone_generation = 0
+        zone_generation = ZoneGeneration(
+            zone_id=zone.id, generation=next_zone_generation, final_timestamp=None
+        )
+        session.add(zone_generation)
         session.flush()
 
-    # modify old and insert new zone generation
-    if zone_already_exists:
-        zone_generation_query = (session
-            .query(ZoneGeneration)
-            .filter(ZoneGeneration.zone_id == zone.id)
-            .order_by(ZoneGeneration.generation)
+        # insert centerlines
+        if centerlines is None:
+            G = ox.graph_from_place(osmnx_name, simplify=True, network_type="drive")
+            _, edges = ox.graph_to_gdfs(G)
+
+            # Centerline names entries may be NaN, a str name, or a list[str] of names. AFAIK there
+            # isn't any interesting information in the ordering of names, so we'll use first-wins
+            # rules for list[str]. For NaN names, we'll insert an "Unknown" string.
+            #
+            # Centerline osmid values cannot be NaN, but can map to a list. It's unclear why this
+            # is the case.
+            names = []
+            for edge in G.edges:
+                u, v, _ = edge
+                names.append(_get_name_for_centerline_edge(G, u, v))
+            edges = edges.assign(
+                name=names,
+                osmid=edges.osmid.map(lambda v: v if isinstance(v, int) else v[0])
+            )
+            centerlines = gpd.GeoDataFrame(
+                {"first_zone_generation": zone_generation.id, "last_zone_generation": None,
+                "zone_id": zone.id, "osmid": edges.osmid, "name": edges.name},
+                index=range(len(edges)),
+                geometry=edges.geometry
+            )
+            centerlines.crs = "epsg:4326"
+            centerlines["length_in_meters"] = centerlines.geometry.map(_calculate_linestring_length)
+        
+        else:
+            centerlines["length_in_meters"] = centerlines.geometry.map(_calculate_linestring_length)
+
+        minx, miny, maxx, maxy = centerlines.total_bounds
+        poly = Polygon([[minx, miny], [minx, maxy], [maxx, maxy], [maxx, miny], [minx, miny]])
+        bbox = f'SRID=4326;{str(poly)}'
+        zone.bounding_box = bbox
+
+        connstr, _, _ = get_db(profile)
+        conn = sa.create_engine(connstr)
+
+        # Cap the previous centerline generations (see previous comment).
+        previously_current_centerlines = (session
+            .query(Centerline)
+            .filter_by(zone_id=zone.id, last_zone_generation=None)
             .all()
         )
-        next_zone_generation = zone_generation_query[-1].generation + 1
-    else:
-        next_zone_generation = 0
-    zone_generation = ZoneGeneration(
-        zone_id=zone.id, generation=next_zone_generation, final_timestamp=None
-    )
-    session.add(zone_generation)
-    session.flush()
+        for previously_current_centerline in previously_current_centerlines:
+            previously_current_centerline.last_zone_generation = next_zone_generation - 1
 
-    # insert centerlines
-    if centerlines is None:
-        G = ox.graph_from_place(osmnx_name, simplify=True, network_type="drive")
-        _, edges = ox.graph_to_gdfs(G)
-
-        # Centerline names entries may be NaN, a str name, or a list[str] of names. AFAIK there
-        # isn't any interesting information in the ordering of names, so we'll use first-wins
-        # rules for list[str]. For NaN names, we'll insert an "Unknown" string.
-        #
-        # Centerline osmid values cannot be NaN, but can map to a list. It's unclear why this
-        # is the case.
-        names = []
-        for edge in G.edges:
-            u, v, _ = edge
-            names.append(_get_name_for_centerline_edge(G, u, v))
-        edges = edges.assign(
-            name=names,
-            osmid=edges.osmid.map(lambda v: v if isinstance(v, int) else v[0])
+        # Set the current zone generation's final timestamp.
+        current_zone_generation = (session
+            .query(ZoneGeneration)
+            .filter_by(zone_id=zone.id)
+            .order_by(sa.desc(ZoneGeneration.id))
+            .first()
         )
-        centerlines = gpd.GeoDataFrame(
-            {"first_zone_generation": zone_generation.id, "last_zone_generation": None,
-             "zone_id": zone.id, "osmid": edges.osmid, "name": edges.name},
-            index=range(len(edges)),
-            geometry=edges.geometry
-        )
-        centerlines.crs = "epsg:4326"
-        centerlines["length_in_meters"] = centerlines.geometry.map(_calculate_linestring_length)
-    
-    else:
-        centerlines["length_in_meters"] = centerlines.geometry.map(_calculate_linestring_length)
+        if current_zone_generation:
+            current_zone_generation.final_timestamp = datetime.now()
 
-    minx, miny, maxx, maxy = centerlines.total_bounds
-    poly = Polygon([[minx, miny], [minx, maxy], [maxx, maxy], [maxx, miny], [minx, miny]])
-    bbox = f'SRID=4326;{str(poly)}'
-    zone.bounding_box = bbox
+        session.add(zone)
+        session.add(zone_generation)
 
-    connstr, _, _ = get_db(profile)
-    conn = sa.create_engine(connstr)
+        try:
+            session.commit()
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                centerlines.to_postgis("centerlines", conn, if_exists="append")
+        except:
+            session.rollback()
+            raise
+        finally:
+            engine = session.bind
+            session.close()
+            engine.dispose()
 
-    # Cap the previous centerline generations (see previous comment).
-    previously_current_centerlines = (session
-        .query(Centerline)
-        .filter_by(zone_id=zone.id, last_zone_generation=None)
-        .all()
-    )
-    for previously_current_centerline in previously_current_centerlines:
-        previously_current_centerline.last_zone_generation = next_zone_generation - 1
-
-    # Set the current zone generation's final timestamp.
-    current_zone_generation = (session
-        .query(ZoneGeneration)
-        .filter_by(zone_id=zone.id)
-        .order_by(sa.desc(ZoneGeneration.id))
-        .first()
-    )
-    if current_zone_generation:
-        current_zone_generation.final_timestamp = datetime.now()
-
-    session.add(zone)
-    session.add(zone_generation)
-
-    try:
-        session.commit()
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            centerlines.to_postgis("centerlines", conn, if_exists="append")
-    except:
-        session.rollback()
-        raise
-    finally:
-        session.close()
-
-def show_zones(profile):
+def show_zones(profile, wait=5, force_download=False):
     """Pretty-prints a list of zones in the database."""
-    session = db_sessionmaker(profile)()
-    zones = (session
-        .query(Zone)
-        .all()
-    )
-    if len(zones) == 0:
-        print("No zones in the database. :(")
-    else:
-        console = Console()
-        table = Table(show_header=True, header_style="bold magenta")
-        table.add_column("ID", justify="left")
-        table.add_column("Name", justify="left")
-        table.add_column("OSMNX Name", justify="left")
-        table.add_column("N(Generations)", justify="right")
-        table.add_column("N(Centerlines)", justify="right")
-        table.add_column("Bounding Box", justify="left")
-        for zone in zones:
-            zone_gen_ids = [gen.id for gen in zone.zone_generations]
-            n_centerlines = (
-                session.query(Centerline).filter(
-                    Centerline.first_zone_generation.in_(zone_gen_ids)
-                ).count()
-            )
-            bounds = _poly_wkb_to_bounds_str(zone.bounding_box)
-            table.add_row(
-                str(zone.id), zone.name, zone.osmnx_name, str(len(zone.zone_generations)),
-                str(n_centerlines), str(bounds)
-            )
-        console.print(table)
+    with OptionalCloudSQLProxyProcess(profile, wait=wait, force_download=force_download):
+        session = db_sessionmaker(profile)()
+        zones = (session
+            .query(Zone)
+            .all()
+        )
+        if len(zones) == 0:
+            print("No zones in the database. :(")
+        else:
+            console = Console()
+            table = Table(show_header=True, header_style="bold magenta")
+            table.add_column("ID", justify="left")
+            table.add_column("Name", justify="left")
+            table.add_column("OSMNX Name", justify="left")
+            table.add_column("N(Generations)", justify="right")
+            table.add_column("N(Centerlines)", justify="right")
+            table.add_column("Bounding Box", justify="left")
+            for zone in zones:
+                zone_gen_ids = [gen.id for gen in zone.zone_generations]
+                n_centerlines = (
+                    session.query(Centerline).filter(
+                        Centerline.first_zone_generation.in_(zone_gen_ids)
+                    ).count()
+                )
+                bounds = _poly_wkb_to_bounds_str(zone.bounding_box)
+                table.add_row(
+                    str(zone.id), zone.name, zone.osmnx_name, str(len(zone.zone_generations)),
+                    str(n_centerlines), str(bounds)
+                )
+            console.print(table)
 
 def show_dbs():
     """
@@ -362,63 +324,75 @@ def _validate_sector_geom(filepath):
         raise ValueError(f"Input sector has unsupported {sector_shape.geom_type} union type.")
     return sector_shape
 
-def insert_sector(sector_name, filepath, profile):
-    session = db_sessionmaker(profile)()
+def insert_sector(sector_name, filepath, profile, wait=5, force_download=False):
+    with OptionalCloudSQLProxyProcess(profile, wait=wait, force_download=force_download):
+        session = db_sessionmaker(profile)()
 
-    if session.query(Sector).filter_by(name=sector_name).count() != 0:
-        raise ValueError(
-            f"The database already contains a sector with the name {sector_name!r}. "
-            f"If you are redefining the same sector, please run `delete_sector({sector_name!r})` "
-            f"first. Otherwise, please choose a different name for this sector."
-        )
+        if session.query(Sector).filter_by(name=sector_name).count() != 0:
+            raise ValueError(
+                f"The database already contains a sector with the name {sector_name!r}. "
+                f"If you are redefining the same sector, please run `delete_sector({sector_name!r})` "
+                f"first. Otherwise, please choose a different name for this sector."
+            )
 
-    sector_shape = _validate_sector_geom(filepath)
-    sector = Sector(name=sector_name, geometry=f'SRID=4326;{str(sector_shape)}')
-    session.add(sector)
-    try:
-        session.commit()
-    except:
-        session.rollback()
-        raise
-    finally:
-        session.close()
+        sector_shape = _validate_sector_geom(filepath)
+        sector = Sector(name=sector_name, geometry=f'SRID=4326;{str(sector_shape)}')
+        session.add(sector)
+        try:
+            session.commit()
+        except:
+            session.rollback()
+            raise
+        finally:
+            engine = session.bind
+            session.close()
+            engine.dispose()
 
-def delete_sector(sector_name, profile):
-    session = db_sessionmaker(profile)()
+def delete_sector(sector_name, profile, wait=5, force_download=False):
+    """Deletes a sector in the database."""
+    with OptionalCloudSQLProxyProcess(profile, wait=wait, force_download=force_download):
+        session = db_sessionmaker(profile)()
 
-    sector = session.query(Sector).filter_by(name=sector_name).one_or_none()
-    if sector is None:
-        raise ValueError(f"Cannot delete sector {sector_name!r}: no such sector in the database.")
+        sector = session.query(Sector).filter_by(name=sector_name).one_or_none()
+        if sector is None:
+            raise ValueError(f"Cannot delete sector {sector_name!r}: no such sector in the database.")
 
-    session.delete(sector)
-    try:
-        session.commit()
-    except:
-        session.rollback()
-        raise
-    finally:
-        session.close()
+        session.delete(sector)
+        try:
+            session.commit()
+        except:
+            session.rollback()
+            raise
+        finally:
+            engine = session.bind
+            session.close()
+            engine.dispose()
 
-def show_sectors(profile):
+def show_sectors(profile, wait=5, force_download=False):
     """Pretty-prints a list of sectors in the database."""
-    session = db_sessionmaker(profile)()
-    
-    sectors = session.query(Sector).all()
-    if len(sectors) == 0:
-        print("No sectors in the database. :(")
-        return
+    with OptionalCloudSQLProxyProcess(profile, wait=wait, force_download=force_download):
+        try:
+            session = db_sessionmaker(profile)()
+            
+            sectors = session.query(Sector).all()
+            if len(sectors) == 0:
+                print("No sectors in the database. :(")
+                return
 
-    console = Console()
-    table = Table(show_header=True, header_style="bold magenta")
-    table.add_column("ID", justify="left")
-    table.add_column("Name", justify="left")
-    table.add_column("Bounding Box", justify="left")
-    for sector in session.query(Sector).all():
-        bounds = _poly_wkb_to_bounds_str(sector.geometry)
-        table.add_row(str(sector.id), sector.name, bounds)
-    console.print(table)
+            console = Console()
+            table = Table(show_header=True, header_style="bold magenta")
+            table.add_column("ID", justify="left")
+            table.add_column("Name", justify="left")
+            table.add_column("Bounding Box", justify="left")
+            for sector in session.query(Sector).all():
+                bounds = _poly_wkb_to_bounds_str(sector.geometry)
+                table.add_row(str(sector.id), sector.name, bounds)
+            console.print(table)
+        finally:
+            engine = session.bind
+            session.close()
+            engine.dispose()
 
 __all__ = [
-    'update_zone', 'show_zones', 'insert_sector', 'delete_sector', 'show_sectors',
-    'run_cloud_sql_proxy'
+    'update_zone', 'show_zones', 'insert_sector', 'delete_sector', 'show_sectors'
 ]

--- a/python/rubbish_geo_common/rubbish_geo_common/db_ops.py
+++ b/python/rubbish_geo_common/rubbish_geo_common/db_ops.py
@@ -6,6 +6,8 @@ import click
 import pathlib
 import os
 import configparser
+import warnings
+import time
 
 import sqlalchemy as sa
 from sqlalchemy.orm.session import sessionmaker
@@ -14,6 +16,101 @@ from rubbish_geo_common.orm import (
 )
 
 APPDIR = pathlib.Path(click.get_app_dir("rubbish", force_posix=True))
+
+def run_cloud_sql_proxy(profile, force_download=False):
+    """
+    Internal method. Does the song and dance Google requires to shell psql through to a DB.
+    """
+    import pathlib
+    import click
+    import subprocess
+    import socket
+    import stat
+    import requests
+
+    if profile is None:
+        profile = 'default'
+
+    APPDIR = pathlib.Path(click.get_app_dir("rubbish", force_posix=True))
+    outpath = APPDIR / "cloud_sql_proxy"
+    if not outpath.exists() or force_download:
+        # this is the macOS path, so this method only currently works on macOS
+        dl_url = "https://dl.google.com/cloudsql/cloud_sql_proxy.darwin.amd64"
+        proxy_bytes = requests.get(dl_url)
+        proxy_bytes.raw.decode_content = True
+        with open(outpath, "wb") as f:
+            try:
+                f.write(proxy_bytes.content)
+            except PermissionError:
+                raise PermissionError(
+                    "Could not download the cloud_sql_proxy script to your local home folder "
+                    "due to a permissions error. Follow the instructions in the GCP docs "
+                    "(https://cloud.google.com/sql/docs/postgres/sql-proxy) and download the "
+                    "executable to the ~/.rubbish/cloud_sql_proxy path on your local machine."
+                )
+
+        try:
+            os.chmod(outpath, stat.S_IEXEC)
+        except OSError:
+            raise OSError(
+                "Could not mark the cloud_sql_proxy script as executable. You may have to do "
+                "this yourself: run 'chmod +x ~/.rubbish/cloud_sql_proxy' in the terminal."
+            )
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        port_occupied = s.connect_ex(('localhost', 5432)) == 0
+    if port_occupied:
+        raise OSError(
+            "This method needs to launch the cloud_sql_proxy daemon on port 5432, but port is "
+            "already in use. You will have to free the port first."
+        )
+
+    _, _, conname = get_db(profile)
+    popen = subprocess.Popen([f"{outpath.as_posix()}", f"-instances={conname}=tcp:5432"])
+    print("Launched cloud_sql_proxy process with PID {popen.pid}.")
+    return popen
+
+def shut_down_cloud_sql_proxy(popen):
+    """
+    Shuts down (terminates) a Cloud SQL Proxy process, as returned by `run_cloud_sql_proxy`.
+    """
+    pid = popen.pid
+    try:
+        popen.terminate()
+    except:
+        warnings.warn(
+            f"Could not terminate Cloud SQL Proxy process (PID {pid}), killing it instead."
+        )
+        popen.kill()
+
+class OptionalCloudSQLProxyProcess:
+    """
+    Context manager class which launches a cloud SQL proxy process in the background if one is
+    needed, and manages the lifecycle of that process (startup/shutdown).
+    
+    This is not needed when connecting to a local database. In that case, this context manager
+    does nothing. Hence "Optional".
+    """
+    def __init__(self, profile, wait=5, force_download=False):
+        self.profile = profile
+        self.wait = wait
+        self.force_download = force_download
+
+        _, conntype, _ = get_db(self.profile)
+        self.conntype = conntype
+
+    def __enter__(self):
+        if self.conntype == 'gcp':
+            process = run_cloud_sql_proxy(self.profile, force_download=self.force_download)
+            self.process = process
+
+            print(f"Waiting {self.wait} seconds for cloud_sql_proxy process to initialize...")
+            time.sleep(self.wait)
+            print(f"Finished waiting, continuing execution...")
+    
+    def __exit__(self, type, value, traceback):
+        if self.conntype == 'gcp':
+            shut_down_cloud_sql_proxy(self.process)
 
 def set_db(profile, connstr, conntype, conname=None):
     """
@@ -84,32 +181,37 @@ def db_sessionmaker(profile):
     engine = sa.create_engine(connstr)
     return sessionmaker(bind=engine)
 
-def reset_db(profile):
+def reset_db(profile, wait=5, force_download=False):
     """
     Resets the current database, deleting all data.
     """
-    session = db_sessionmaker(profile)()
+    with OptionalCloudSQLProxyProcess(profile, wait=wait, force_download=force_download):
+        session = db_sessionmaker(profile)()
 
-    engine = session.bind
-    engine.execute('ALTER SEQUENCE zones_id_seq RESTART WITH 1;')
-    engine.execute('ALTER SEQUENCE zone_generations_id_seq RESTART WITH 1;')
-    engine.execute('ALTER SEQUENCE blockface_statistics_id_seq RESTART WITH 1;')
-    engine.execute('ALTER SEQUENCE pickups_id_seq RESTART WITH 1;')
-    engine.execute('ALTER SEQUENCE sectors_id_seq RESTART WITH 1;')
-    engine.execute('ALTER SEQUENCE centerlines_id_seq RESTART WITH 1;')
+        engine = session.bind
+        engine.execute('ALTER SEQUENCE zones_id_seq RESTART WITH 1;')
+        engine.execute('ALTER SEQUENCE zone_generations_id_seq RESTART WITH 1;')
+        engine.execute('ALTER SEQUENCE blockface_statistics_id_seq RESTART WITH 1;')
+        engine.execute('ALTER SEQUENCE pickups_id_seq RESTART WITH 1;')
+        engine.execute('ALTER SEQUENCE sectors_id_seq RESTART WITH 1;')
+        engine.execute('ALTER SEQUENCE centerlines_id_seq RESTART WITH 1;')
 
-    try:
-        session.query(Pickup).delete()
-        session.query(BlockfaceStatistic).delete()
-        session.query(Centerline).delete()
-        session.query(Sector).delete()
-        session.query(ZoneGeneration).delete()
-        session.query(Zone).delete()
-        session.commit()
-    except:
-        session.rollback()
-        raise
-    finally:
-        session.close()
+        try:
+            session.query(Pickup).delete()
+            session.query(BlockfaceStatistic).delete()
+            session.query(Centerline).delete()
+            session.query(Sector).delete()
+            session.query(ZoneGeneration).delete()
+            session.query(Zone).delete()
+            session.commit()
+        except:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+            engine.dispose()
 
-__all__ = ['set_db', 'get_db_cfg', 'get_db', 'db_sessionmaker', 'reset_db']
+__all__ = [
+    'set_db', 'get_db_cfg', 'get_db', 'db_sessionmaker', 'reset_db', 'run_cloud_sql_proxy',
+    'OptionalCloudSQLProxyProcess'
+]


### PR DESCRIPTION
Admin commands were not working when targeting `{dev, prod}` because `cloud_sql_proxy` was not initialized for you (needed for external connectivity to the GCP database service). This PR adds a `OptionalCloudSQLProxyProcess` context manager which automatically manages the lifecycle of the relevantly parameterized `cloud_sql_proxy` process for those methods that need it.