### PR TITLE
Update field names.

### DIFF
--- a/js/functions/index.js
+++ b/js/functions/index.js
@@ -79,9 +79,10 @@ exports.proxy_POST_PICKUPS = functions.runWith(opts).firestore.document('/Rubbis
         return null;  // sentinal value for filter(v => v)
       }
 
-      // The curb is allowed to be empty. Runs that predate this service lack one. The analytics
-      // service will attempt to use the distribution of the data to guess its value.
-      const curb = ("curb" in photoStoryData) ? photoStoryData.curb : null;
+      // NOTE(aleksey): The curb is allowed to be empty. Runs that predate this service lack one.
+      // NOTE(aleksey): The user database calls this field "roadSnapping". We rename the field to
+      // curb here, because that is a much better name. It'd be nice if we used curb everywhere.
+      const curb = ("roadSnapping" in photoStoryData) ? photoStoryData.roadSnapping : null;
 
       firebaseRunID = photoStoryData.photoStoryID;
       const type = photoStoryData.rubbishType;

--- a/python/functions/main.py
+++ b/python/functions/main.py
@@ -84,7 +84,7 @@ def POST_pickups(request):
                 "firebase_id": <int>,
                 "type": <str; from {'tobacco', 'paper', 'plastic', 'other', 'food', 'glass'}>,
                 "timestamp": <int; UTC UNIX timestamp>,
-                "curb": <{'left', 'right', 'center', None}; side of the street>,
+                "curb": <{'left', 'right', 'middle', None}; side of the street>,
                 "geometry": <str; POINT in WKT format>
             }
         ]

--- a/python/migrations/versions/a3fa9dac3f4e_initialize_db.py
+++ b/python/migrations/versions/a3fa9dac3f4e_initialize_db.py
@@ -79,7 +79,7 @@ def upgrade():
         sa.Column("geometry", Geometry("POINT", srid=4326), nullable=False),
         sa.Column("snapped_geometry", Geometry("POINT", srid=4326), nullable=False),
         sa.Column("linear_reference", sa.Float(precision=3), nullable=False),
-        sa.Column("curb", ENUM('left', 'right', 'center', name='curb'), nullable=False)
+        sa.Column("curb", ENUM('left', 'right', 'middle', name='curb'), nullable=False)
     )
     # Blockfaces are a psuedo-virtual table defined by the combination of {centerline,curb}.
     # A centerline will typically have two blockfaces: one for the left side of the street and
@@ -91,7 +91,7 @@ def upgrade():
         "blockface_statistics",
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column("centerline_id", sa.Integer, sa.ForeignKey("centerlines.id"), nullable=False),
-        sa.Column("curb", ENUM('left', 'right', 'center', name='curb'), nullable=False),
+        sa.Column("curb", ENUM('left', 'right', 'middle', name='curb'), nullable=False),
         sa.Column("rubbish_per_meter", sa.Float, nullable=False, index=True),
         sa.Column("num_runs", sa.Integer, nullable=False)
     )

--- a/python/rubbish_geo_client/rubbish_geo_client/ops.py
+++ b/python/rubbish_geo_client/rubbish_geo_client/ops.py
@@ -133,7 +133,7 @@ def write_pickups(pickups, profile, check_distance=True):
      "firebase_run_id": <str>,
      "type": <str, from RUBBISH_TYPES>,
      "timestamp": <int; UTC UNIX timestamp>,
-     "curb": <{left, right, center, None}; user statement of side of the street>,
+     "curb": <{left, right, middle, None}; user statement of side of the street>,
      "geometry": <str; POINT in WKT format>}
     ```
 
@@ -176,10 +176,10 @@ def write_pickups(pickups, profile, check_distance=True):
                 f"timestamp is actually a UTC UNIX timestamp?"
             )
         curb = pickup["curb"]
-        if curb not in [None, "left", "right", "center"]:
+        if curb not in [None, "left", "right", "middle"]:
             raise ValueError(
                 f"Found pickup with invalid curb value {curb} "
-                f"(must be one of 'left', 'right', 'center', None)."
+                f"(must be one of 'left', 'right', 'middle', None)."
             )
         if pickup["type"] not in RUBBISH_TYPES:
             raise ValueError(
@@ -520,7 +520,7 @@ def radial_get(coord, distance, profile, include_na=False, offset=0):
             centerline_dict = centerline_obj_to_dict(statistic.centerline)
             response_map[statistic.centerline_id] = {
                 'centerline': centerline_dict,
-                'statistics': {'left': None, 'center': None, 'right': None}
+                'statistics': {'left': None, 'middle': None, 'right': None}
             }
         statistic_dict = blockface_statistic_obj_to_dict(statistic)
         response_map[statistic.centerline_id]['statistics'][statistic.curb] = statistic_dict
@@ -529,7 +529,7 @@ def radial_get(coord, distance, profile, include_na=False, offset=0):
             if centerline.id not in response_map:
                 response_map[centerline.id] = {
                     'centerline': centerline_obj_to_dict(centerline),
-                    'statistics': {'left': None, 'center': None, 'right': None}
+                    'statistics': {'left': None, 'middle': None, 'right': None}
                 }
     if len(response_map) == 0:
         return []
@@ -595,7 +595,7 @@ def sector_get(sector_name, profile, include_na=False, offset=0):
             centerline_dict = centerline_obj_to_dict(statistic.centerline)
             response_map[statistic.centerline_id] = {
                 'centerline': centerline_dict,
-                'statistics': {'left': None, 'center': None, 'right': None}
+                'statistics': {'left': None, 'middle': None, 'right': None}
             }
         statistic_dict = blockface_statistic_obj_to_dict(statistic)
         response_map[statistic.centerline_id]['statistics'][statistic.curb] = statistic_dict
@@ -604,7 +604,7 @@ def sector_get(sector_name, profile, include_na=False, offset=0):
             if centerline.id not in response_map:
                 response_map[centerline.id] = {
                     'centerline': centerline_obj_to_dict(centerline),
-                    'statistics': {'left': None, 'center': None, 'right': None}
+                    'statistics': {'left': None, 'middle': None, 'right': None}
                 }
     return [response_map[centerline_id] for centerline_id in response_map]
 
@@ -666,8 +666,8 @@ def coord_get(coord, profile, include_na=False):
         statistics['left'] = None
     if 'right' not in statistics:
         statistics['right'] = None
-    if 'center' not in statistics:
-        statistics['center'] = None
+    if 'middle' not in statistics:
+        statistics['middle'] = None
     return {"centerline": centerline_obj_to_dict(centerline), "statistics": statistics}
 
 def run_get(run_id, profile):
@@ -720,7 +720,7 @@ def run_get(run_id, profile):
             centerline_dict = centerline_obj_to_dict(statistic.centerline)
             response_map[statistic.centerline_id] = {
                 'centerline': centerline_dict,
-                'statistics': {'left': None, 'center': None, 'right': None}
+                'statistics': {'left': None, 'middle': None, 'right': None}
             }
         statistic_dict = blockface_statistic_obj_to_dict(statistic)
         response_map[statistic.centerline_id]['statistics'][statistic.curb] = statistic_dict

--- a/python/rubbish_geo_common/rubbish_geo_common/orm.py
+++ b/python/rubbish_geo_common/rubbish_geo_common/orm.py
@@ -78,7 +78,7 @@ class Pickup(Base):
     geometry = sa.Column("geometry", Geometry("POINT"), nullable=False)
     snapped_geometry = sa.Column("snapped_geometry", Geometry("POINT"), nullable=False)
     linear_reference = sa.Column("linear_reference", sa.Float(precision=3), nullable=False)
-    curb = sa.Column("curb", ENUM('left', 'right', 'center', name='curb'), nullable=False)
+    curb = sa.Column("curb", ENUM('left', 'right', 'middle', name='curb'), nullable=False)
     centerline = relationship("Centerline", back_populates="pickups")
 
     def __repr__(self):
@@ -96,7 +96,7 @@ class BlockfaceStatistic(Base):
     id = sa.Column("id", sa.Integer, primary_key=True)
     centerline_id =\
         sa.Column("centerline_id", sa.Integer, sa.ForeignKey("centerlines.id"), nullable=False)
-    curb = sa.Column("curb", ENUM('left', 'right', 'center', name='curb'), nullable=False)
+    curb = sa.Column("curb", ENUM('left', 'right', 'middle', name='curb'), nullable=False)
     rubbish_per_meter = sa.Column("rubbish_per_meter", sa.Float, nullable=False)
     num_runs = sa.Column("num_runs", sa.Integer, nullable=False)
     centerline = relationship("Centerline", back_populates="blockface_statistics")


### PR DESCRIPTION
These field names are different in the upstream user database.

Because this commit modifies the root database migration (to change `"center"` to `"middle"`), it will require rolling the database. I _could_ just write a database migration to get around this, but since there's no real data in just yet it's less tech debt-y to just pay the one-time cost of rolling the database.